### PR TITLE
Add APIs for Attractions and Categories

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,20 +1,123 @@
 from flask import *
-app=Flask(__name__)
-app.config["JSON_AS_ASCII"]=False
-app.config["TEMPLATES_AUTO_RELOAD"]=True
+import mysql.connector, mysql.connector.pooling
+app = Flask(__name__)
+app.config["JSON_AS_ASCII"] = False
+app.config['JSON_SORT_KEYS'] = False
+app.config["TEMPLATES_AUTO_RELOAD"] = True
+
+dbconfig = {
+	"host": "localhost",
+	"user": "root",
+	"password": "12345678",
+	"database": "taipei_day_trip",
+	"buffered": True
+}
+cnxpool = mysql.connector.pooling.MySQLConnectionPool(
+	pool_name = "taipei_day_trip_pool",
+	pool_size = 3,
+	**dbconfig)
 
 # Pages
 @app.route("/")
 def index():
 	return render_template("index.html")
+
 @app.route("/attraction/<id>")
 def attraction(id):
 	return render_template("attraction.html")
+
 @app.route("/booking")
 def booking():
 	return render_template("booking.html")
+
 @app.route("/thankyou")
 def thankyou():
 	return render_template("thankyou.html")
 
-app.run(port=3000)
+# RESTful API
+@app.route("/api/attractions", methods = ["GET"])
+def get_attractions():
+	page = request.args.get("page", 0, int)
+	keyword = request.args.get("keyword", None)
+	id_start = page * 12
+	id_end = id_start + 12
+	if keyword == None:
+		try:
+			cnx = cnxpool.get_connection()
+			cnxcursor = cnx.cursor(dictionary = True)
+			cnxcursor.execute("SELECT * FROM attractions")
+			attractions = cnxcursor.fetchall()
+			# Change the value of "images" into a list
+			for attraction in attractions:
+				images = attraction["images"].split(" ")
+				images.pop() # Remove the last space
+				attraction["images"] = images
+			next_page = page + 1
+			# Check if there is the last page
+			if len(attractions) / 12 < page + 1:
+				next_page = None
+			return jsonify({"nextPage": next_page, "data": attractions[id_start : id_end]})
+		except:
+			return jsonify({"error": True, "message": "伺服器內部錯誤"}), 500
+		finally:
+			cnxcursor.close()
+			cnx.close()
+	else:
+		try:
+			cnx = cnxpool.get_connection()
+			cnxcursor = cnx.cursor(dictionary = True)
+			cnxcursor.execute("SELECT * FROM attractions WHERE category=%s OR name LIKE %s", (keyword, "%" + keyword + "%"))
+			attractions = cnxcursor.fetchall()
+			# Change the value of "images" into a list
+			for attraction in attractions:
+				images = attraction["images"].split(" ")
+				images.pop() # Remove the last space
+				attraction["images"] = images
+			next_page = page + 1
+			# Check if there is the last page
+			if len(attractions) / 12 <= page + 1:
+				next_page = None
+			return jsonify({"nextPage": next_page, "data": attractions[id_start : id_end]})
+		except:
+			return jsonify({"error": True, "message": "伺服器內部錯誤"}), 500
+		finally:
+			cnxcursor.close()
+			cnx.close()
+
+@app.route("/api/attraction/<attractionId>", methods = ["GET"])
+def get_attraction_by_id(attractionId):
+	try:
+		cnx = cnxpool.get_connection()
+		cnxcursor = cnx.cursor(dictionary = True)
+		cnxcursor.execute("SELECT * FROM attractions WHERE id =%s", (attractionId, ))
+		attraction_data = cnxcursor.fetchone()
+		if attraction_data:
+			images = attraction_data["images"].split(" ")
+			images.pop() # Remove the last space
+			attraction_data["images"] = images
+			return jsonify({"data": attraction_data})
+		# If id is not found
+		else:
+			return jsonify({"error": True, "message": "景點編號不正確"}), 400
+	except:
+		return jsonify({"error": True, "message": "伺服器內部錯誤"}), 500
+	finally:
+		cnxcursor.close()
+		cnx.close()
+
+@app.route("/api/categories", methods = ["GET"])
+def get_categories():
+	try:
+		cnx = cnxpool.get_connection()
+		cnxcursor = cnx.cursor()
+		cnxcursor.execute("SELECT DISTINCT category FROM attractions")
+		categories = [category[0] for category in cnxcursor.fetchall()] # Change a tuple from fetchall to a list
+		return jsonify({"data": categories})
+	except:
+		return jsonify({"error": True, "message": "伺服器內部錯誤"}), 500
+	finally:
+		cnxcursor.close()
+		cnx.close()
+
+if __name__ == "__main__":
+	app.run(port = 3000)

--- a/data/get_attractions.py
+++ b/data/get_attractions.py
@@ -1,0 +1,37 @@
+import json
+import mysql.connector
+
+dbconfig = {
+    "host": "localhost",
+    "user": "root",
+    "password": "12345678",
+    "database": "taipei_day_trip",
+    "buffered": True
+}
+
+with open("taipei-attractions.json", mode = "r", encoding = "utf-8") as file:
+    data = json.load(file)
+attractions = data["result"]["results"]
+
+def split_file(file):
+    all_url = file.split("https://")
+    images = ""
+    for i in range(len(all_url)):
+        if all_url[i].lower().endswith(".jpg") or all_url[i].lower().endswith(".png"):
+            images = images + "https://" + all_url[i] + " "
+    return images
+
+# Get data of attractions from JSON and insert into table "attractions"
+try:
+    cnx = mysql.connector.connect(**dbconfig)
+    cnxcursor = cnx.cursor()
+    for attraction in attractions:    
+        add_attraction = "INSERT INTO attractions(name, category, description, address, transport, mrt, lat, lng, images) VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s)"
+        attraction_data = (attraction["name"], attraction["CAT"], attraction["description"], attraction["address"].replace(" ", ""), attraction["direction"], attraction["MRT"], float(attraction["latitude"]), float(attraction["longitude"]), split_file(attraction["file"]))
+        cnxcursor.execute(add_attraction, attraction_data)
+        cnx.commit()
+except mysql.connector.Error as err:
+    print("Something went wrong: {}".format(err))
+finally:
+    cnxcursor.close()
+    cnx.close()


### PR DESCRIPTION
### Add APIs for attractions and categories
- Add /api/attraction to get attractions from database which can be filtered by keyword
- Add /api/attraction/attractionId to get data of attraction by id
- Add /api/categories to get categories of attractions

### Deploy python flask server on AWS EC2
- http://3.115.107.58:3000/api/attractions?page=1
- http://3.115.107.58:3000/api/attractions?page=0&keyword=藝文館所
- http://3.115.107.58:3000/api/attractions?page=0&keyword=北
- http://3.115.107.58:3000/api/attraction/10